### PR TITLE
Use pythonw on Windows to hide console when linting

### DIFF
--- a/Flake8Lint.py
+++ b/Flake8Lint.py
@@ -99,7 +99,10 @@ class Flake8LintCommand(sublime_plugin.TextCommand):
         else:
             # else - check interpreter
             if interpreter == 'auto':
-                interpreter = 'python'
+                if os.name == 'nt':
+                    interpreter = 'pythonw'
+                else:
+                    interpreter = 'python'
             elif not os.path.exists(interpreter):
                 sublime.error_message(
                     "Python Flake8 Lint error:\n"


### PR DESCRIPTION
The linter checks files when they're saved, which is nice, but on Windows this shows a python window briefly, which is less nice. Using `pythonw` to run the linter prevents this, making things seem much more, um, seamless. Just a small thing, but it makes me happy. :)
