### PR TITLE
Resolve conflict with pylint annotations

### DIFF
--- a/Flake8Lint.py
+++ b/Flake8Lint.py
@@ -64,10 +64,15 @@ def skip_line(line):
     Check if we need to skip line check.
     Line must ends with '# noqa' or '# NOQA' comment.
     """
-    if line.strip().lower().endswith('# noqa'):
+    def _noqa(line):
+        return line.strip().lower().endswith('# noqa')
+    skip = _noqa(line)
+    if not skip:
+        i = line.rfind(' #')
+        skip = _noqa(line[:i]) if i > 0 else False
+    if skip:
         debug("skip line '{0}'".format(line))
-        return True
-    return False
+    return skip
 
 
 def get_current_line(view):


### PR DESCRIPTION
This commit enables you to mix flake8 and pylint in-line annotations as described here:
https://bitbucket.org/tarek/flake8/issue/58/compatibility-with-pylint-ignore-messages

This is a direct port of `skip_line` code in flake8 (as in "copy & paste").
