### PR TITLE
Add flake8lint-import-order's application-import-names option

### DIFF
--- a/Flake8Lint.py
+++ b/Flake8Lint.py
@@ -47,7 +47,8 @@ PROJECT_SETTINGS_KEYS = (
     'python_interpreter', 'builtins', 'pyflakes', 'pep8', 'pydocstyle',
     'naming', 'debugger', 'import_order', 'import_order_style', 'complexity',
     'pep8_max_line_length', 'select', 'ignore', 'ignore_files',
-    'use_flake8_global_config', 'use_flake8_project_config',
+    'use_flake8_global_config', 'use_flake8_project_config', 
+    'application_import_names'
 )
 FLAKE8_SETTINGS_KEYS = (
     'ignore', 'select', 'ignore_files', 'pep8_max_line_length'
@@ -214,6 +215,10 @@ class Flake8LintSettings(object):
             self.import_order_style = import_order_style
         else:
             self.import_order_style = 'cryptography'
+
+        # get local import names
+        self.application_import_names = self.settings.get(
+            'application_import_names', [])
 
         # turn off complexity check (set number > 0 to check complexity level)
         try:

--- a/Flake8Lint.sublime-settings
+++ b/Flake8Lint.sublime-settings
@@ -40,10 +40,10 @@
 	// report successfull (passed) lint
 	"report_on_success": false,
 
-    // blink gutter marks on success (will not blink with live mode check)
-    // this icon is not depends on 'gutter_marks' settings
-    // please, be careful: this may cause performance issues on ST2
-    "blink_gutter_marks_on_success": true,
+	// blink gutter marks on success (will not blink with live mode check)
+	// this icon is not depends on 'gutter_marks' settings
+	// please, be careful: this may cause performance issues on ST2
+	"blink_gutter_marks_on_success": true,
 
 	// load global flake8 config ("~/.config/flake8")
 	"use_flake8_global_config": true,
@@ -76,6 +76,10 @@
 	// import order style: "cryptography" or "google"
 	// See also: https://github.com/public/flake8-import-order#configuration
 	"import-order-style": "cryptography",
+	// Import names that should be considered local to your application
+	// See also: https://github.com/public/flake8-import-order#configuration
+	"application-import-names": [],
+
 	// turn off complexity check (set number > 0 to check complexity level)
 	"complexity": -1,
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Default "Python Flake8 Lint" plugin config: <kbd>Preferences</kbd>-><kbd>Package
 	// import order style: "cryptography" or "google"
 	// See also: https://github.com/public/flake8-import-order#configuration
 	"import-order-style": "cryptography",
+	// Import names that should be considered local to your application
+	// See also: https://github.com/public/flake8-import-order#configuration
+	"application-import-names": [],
+
 	// turn off complexity check (set number > 0 to check complexity level)
 	"complexity": -1,
 
@@ -199,6 +203,7 @@ You could define per-project config for "Python Flake8 Lint". Use <kbd>Project</
 			"naming": true,
 			"import-order": true,
 			"import-order-style": "google",
+			"application-import-names": [],
 			"complexity": -1,
 			"pep8_max_line_length": 79,
 			"select": [],

--- a/lint.py
+++ b/lint.py
@@ -123,12 +123,13 @@ class FlakesReporter(object):
 class ImportOrderLinter(ImportOrderChecker):
     """Import order linter."""
 
-    def __init__(self, tree, filename, lines, order_style='cryptography'):
+    def __init__(self, tree, filename, lines, order_style='cryptography', import_names=[]):
         """Initialize linter."""
         super(ImportOrderLinter, self).__init__(filename, tree)
         self.lines = lines
         self.options = {
             'import_order_style': order_style,
+            'application_import_names': import_names
         }
 
     def load_file(self):
@@ -262,7 +263,9 @@ def lint(lines, settings):
         # lint with import order
         if settings.get('import-order', True):
             order_style = settings.get('import_order_style')
-            import_linter = ImportOrderLinter(tree, None, lines, order_style)
+            application_imports = settings.get('application_import_names', [])
+            import_linter = ImportOrderLinter(
+                tree, None, lines, order_style, application_imports)
             for error in import_linter.run():
                 warnings.append(error[0:3])
 


### PR DESCRIPTION
Adds the ```application-import-names``` option for flake8lint-import-order, allowing users to declare packages that are considered local to their application.