### PR TITLE
Expanded variables for custom python interpreter

### DIFF
--- a/Flake8Lint.py
+++ b/Flake8Lint.py
@@ -1169,6 +1169,11 @@ class Flake8Lint(object):
         """Do view lint asynchronously."""
         # try to get interpreter
         interpreter = view_settings.get('python_interpreter', 'auto')
+        if '$' in interpreter and int(sublime.version()) > 3068:
+            interpreter = sublime.expand_variables(
+                interpreter, view.window().extract_variables()
+            )
+
         log("python interpreter: {0}".format(interpreter))
 
         lines = view.substr(sublime.Region(0, view.size()))

--- a/Flake8Lint.py
+++ b/Flake8Lint.py
@@ -1169,7 +1169,7 @@ class Flake8Lint(object):
         """Do view lint asynchronously."""
         # try to get interpreter
         interpreter = view_settings.get('python_interpreter', 'auto')
-        if '$' in interpreter and int(sublime.version()) > 3068:
+        if '$' in interpreter and int(sublime.version()) >= 3068:
             interpreter = sublime.expand_variables(
                 interpreter, view.window().extract_variables()
             )


### PR DESCRIPTION
This would allow using sublime build expanded variables, for setting python interpreter in project files, i.e.:

```javascript
"python_interpreter": "${folder/src/scripts/}/python.exe"
```

Should work on build 3068 and later.