### PR TITLE
[Fixed] Generate new color scheme

### DIFF
--- a/color_theme.py
+++ b/color_theme.py
@@ -10,6 +10,7 @@ Based on https://github.com/JulianEberius/SublimePythonIDE
 import codecs
 import os
 import sys
+
 from xml.etree import ElementTree
 
 try:
@@ -192,12 +193,12 @@ def update_color_scheme(settings):
 
         # ST does not expect platform specific paths here, but only
         # forward-slash separated paths relative to "Packages"
-        new_theme_setting = '/'.join(['Packages', 'User', new_name])
-        prefs.set('color_scheme', new_theme_setting)
-        sublime.save_settings('Preferences.sublime-settings')
+        # new_theme_setting = '/'.join(['Packages', 'User', new_name])
+        # prefs.set('color_scheme', new_theme_setting)
+        # sublime.save_settings('Preferences.sublime-settings')
 
     # run async
-    if sublime3:
-        sublime.set_timeout_async(generate_color_scheme_async, 0)
-    else:
-        sublime.set_timeout(generate_color_scheme_async, 100)
+    # if sublime3:
+    #     sublime.set_timeout_async(generate_color_scheme_async, 0)
+    # else:
+    #     sublime.set_timeout(generate_color_scheme_async, 100)


### PR DESCRIPTION
See also [**similar pull request**](https://github.com/JulianEberius/SublimePythonIDE/pull/87).

### 1. Behavior before pull request

New color scheme `User/SashaSublime Flake8Lint (SL).tmTheme` create and replace current color scheme in `User/Preferences.sublime-settings` after Sublime Text restart.

### 2. Behavior after pull request

New color scheme don't generate and don't replace current color scheme.

### 3. Reasons

1. [**Users may well manually**](https://github.com/Kristinita/SashaSublime/blob/SashaDevelop/SashaSublime.tmTheme#L2581-L2632) add [**these lines**](https://github.com/dreadatour/Flake8Lint/blob/master/color_theme.py#L42-L95) in `tmTheme` file of user preferred scheme.
2. I am color scheme developer. Each time, when I need to change my color scheme, I need change in my `User/Preferences.sublime-settings` file `"color_scheme": "Packages/SashaSublime/SashaSublime.tmTheme"` to `User/SashaSublime Flake8Lint (SL).tmTheme`. It takes a lot of time.
3. Some Sublime Text packages also generate own color schemes. Examples:

+ [**PythonIDE**](https://github.com/JulianEberius/SublimePythonIDE/pull/87),
+ [**PersistentRegexHighlight**](https://github.com/skuroda/PersistentRegexHighlight/issues/22),
+ [**Color Highlighter**](https://github.com/Monnoroch/ColorHighlighter/issues/325),
+ [**SublimeLinter3**](https://github.com/SublimeLinter/SublimeLinter3/pull/534),
+ [**Colorcoder**](https://github.com/vprimachenko/Sublime-Colorcoder).  

 Each of these packages create own color scheme. But user may use one color scheme. Color changes of other packages don't applied.

4. I think, is a bad practice — impose user file your color scheme without the user's permission.

### 4. Alternative

You may add option `generate_new_color_scheme_file` in settings. If `false`, new color scheme file don't generate.

Thanks.