### PR TITLE
Remove new trailing line and empty value for settings file parsing

### DIFF
--- a/lint.py
+++ b/lint.py
@@ -180,7 +180,10 @@ def load_flake8_config(filename, global_config=False, project_config=False):
                 if option_type == 'list':
                     option_value = parser.get('flake8', config).strip()
                     if option_value:
-                        result[plugin] = option_value.split(',')
+                        result[plugin] = [v.replace(
+                            '\n', '') for v in option_value.split(',')]
+                        if result[plugin] and not result[plugin][-1]:
+                            del result[plugin][-1]
                 elif option_type == 'int':
                     option_value = parser.get('flake8', config).strip()
                     if option_value:


### PR DESCRIPTION
Parsing settings file like that failed cause of 2 bugs.

```
[flake8]
ignore = 
  D100,
  D102,
```

* `\n` must be remove because Flake8Lint will send to `flake8` an ignore list like that: `['D100\n', 'D102\n']`
* Last comma separator will failed because Flake8Lint will send to `flake8`: `['D100', 'D102', '']` and empty value will ignore all other error codes